### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ships with useful programs such as `nmtui`; the installation can still be done
 through the terminal.
 
 ### Disk Partitioning
-For [impermanence](https://nixos.wiki/wiki/Impermanence), partitioning should
+For [impermanence](https://wiki.nixos.org/wiki/Impermanence), partitioning should
 be done as outlined in the [tmpfs as
 root](https://elis.nu/blog/2020/05/nixos-tmpfs-as-root/) blogpost, but with
 `/nix` as a [LUKS-encrypted file
@@ -27,7 +27,7 @@ Systems](https://nixos.org/manual/nixos/stable/index.html#sec-luks-file-systems)
 sections, ArchWiki's [LVM on
 LUKS](https://wiki.archlinux.org/title/Dm-crypt/Encrypting_an_entire_system#LVM_on_LUKS),
 the unofficial NixOS wiki [Full Disk
-Encryption](https://nixos.wiki/wiki/Full_Disk_Encryption), and [this GitHub
+Encryption](https://wiki.nixos.org/wiki/Full_Disk_Encryption), and [this GitHub
 gist](https://gist.github.com/martijnvermaat/76f2e24d0239470dd71050358b4d5134).
 
 We create a 1GiB EFI boot partition (`/dev/sda1`) and the rest will be our

--- a/hosts/alpha/hardware.nix
+++ b/hosts/alpha/hardware.nix
@@ -5,7 +5,7 @@
   modulesPath,
   ...
 }: {
-  # https://nixos.wiki/wiki/Install_NixOS_on_Hetzner_Cloud
+  # https://wiki.nixos.org/wiki/Install_NixOS_on_Hetzner_Cloud
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
   ];

--- a/hosts/alpha/network.nix
+++ b/hosts/alpha/network.nix
@@ -5,7 +5,7 @@
 }: {
   systemd.network = {
     # Main interface
-    # https://nixos.wiki/wiki/Install_NixOS_on_Hetzner_Cloud
+    # https://wiki.nixos.org/wiki/Install_NixOS_on_Hetzner_Cloud
     networks."10-lan" = {
       matchConfig.Name = "enp1s0";
       address = [

--- a/hosts/delta/hardware.nix
+++ b/hosts/delta/hardware.nix
@@ -5,7 +5,7 @@
   modulesPath,
   ...
 }: {
-  # https://nixos.wiki/wiki/Install_NixOS_on_Hetzner_Cloud
+  # https://wiki.nixos.org/wiki/Install_NixOS_on_Hetzner_Cloud
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
   ];

--- a/hosts/delta/network.nix
+++ b/hosts/delta/network.nix
@@ -1,7 +1,7 @@
 {...}: {
   systemd.network = {
     # Main interface
-    # https://nixos.wiki/wiki/Install_NixOS_on_Hetzner_Cloud
+    # https://wiki.nixos.org/wiki/Install_NixOS_on_Hetzner_Cloud
     networks."10-lan" = {
       matchConfig.Name = "enp1s0";
       address = [

--- a/hosts/sigma/mail.nix
+++ b/hosts/sigma/mail.nix
@@ -10,7 +10,7 @@
 
   # Simple NixOS Mailserver.
   # https://nixos-mailserver.readthedocs.io
-  # https://nixos.wiki/wiki/Imapsync
+  # https://wiki.nixos.org/wiki/Imapsync
   #
   # DNS
   # Each domain delegates mail-handling to mail.caspervk.net using an MX

--- a/modules/base/agenix.nix
+++ b/modules/base/agenix.nix
@@ -6,7 +6,7 @@
   # Agenix manages the deployment of secrets by public-key encrypting them to
   # each system's ssh host key. See the README for more information.
   # https://github.com/ryantm/agenix
-  # https://nixos.wiki/wiki/Comparison_of_secret_managing_schemes
+  # https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes
 
   imports = [
     agenix.nixosModules.default

--- a/modules/base/docker.nix
+++ b/modules/base/docker.nix
@@ -1,7 +1,7 @@
 {...}: {
   # Docker is a utility to pack, ship and run any application as a lightweight
   # container.
-  # https://nixos.wiki/wiki/Docker
+  # https://wiki.nixos.org/wiki/Docker
 
   virtualisation.docker = {
     enable = true;

--- a/modules/base/fish.nix
+++ b/modules/base/fish.nix
@@ -2,8 +2,8 @@
   # Fish is a Unix shell with a focus on interactivity and usability. Fish is
   # designed to give the user features by default, rather than by
   # configuration.
-  # https://nixos.wiki/wiki/Fish
-  # https://nixos.wiki/wiki/Command_Shell
+  # https://wiki.nixos.org/wiki/Fish
+  # https://wiki.nixos.org/wiki/Command_Shell
 
   programs.fish = {
     enable = true;

--- a/modules/base/git.nix
+++ b/modules/base/git.nix
@@ -1,6 +1,6 @@
 {home-manager, ...}: {
   # Git version control system.
-  # https://nixos.wiki/wiki/Git
+  # https://wiki.nixos.org/wiki/Git
 
   home-manager.users.caspervk = {
     programs.git = {

--- a/modules/base/home-manager.nix
+++ b/modules/base/home-manager.nix
@@ -11,7 +11,7 @@
   # in a structure based on the program or service rather than the
   # implementation-specific details of where the output is saved to disk.
   # https://nix-community.github.io/home-manager/
-  # https://nixos.wiki/wiki/Home_Manager
+  # https://wiki.nixos.org/wiki/Home_Manager
   # https://nix-community.github.io/home-manager/options.html
 
   # Import Home Manager to make it part of the NixOS configuration

--- a/modules/base/impermanence.nix
+++ b/modules/base/impermanence.nix
@@ -8,7 +8,7 @@
   # stored in /nix/persist, into the tmpfs root partition on startup. For
   # example: /nix/persist/etc/machine-id is mounted to /etc/machine-id.
   # https://github.com/nix-community/impermanence
-  # https://nixos.wiki/wiki/Impermanence
+  # https://wiki.nixos.org/wiki/Impermanence
   # https://elis.nu/blog/2020/05/nixos-tmpfs-as-root/
 
   imports = [

--- a/modules/base/network.nix
+++ b/modules/base/network.nix
@@ -1,6 +1,6 @@
 {config, ...}: {
-  # https://nixos.wiki/wiki/Networking
-  # https://nixos.wiki/wiki/Systemd-networkd
+  # https://wiki.nixos.org/wiki/Networking
+  # https://wiki.nixos.org/wiki/Systemd-networkd
 
   networking = {
     firewall = {
@@ -34,8 +34,8 @@
   # or
   # > sudo resolvectl log-level debug
   # > sudo journalctl -fu systemd-resolved.service
-  # https://nixos.wiki/wiki/Encrypted_DNS
-  # https://nixos.wiki/wiki/Systemd-resolved
+  # https://wiki.nixos.org/wiki/Encrypted_DNS
+  # https://wiki.nixos.org/wiki/Systemd-resolved
   services.resolved = {
     enable = true;
     dnsovertls = "true";

--- a/modules/base/nix.nix
+++ b/modules/base/nix.nix
@@ -10,7 +10,7 @@
   ];
 
   nix = {
-    # https://nixos.wiki/wiki/Storage_optimization
+    # https://wiki.nixos.org/wiki/Storage_optimization
     gc = {
       # Automatically run the nix garbage collector, removing files from
       # the store that are not referenced by any generation.

--- a/modules/borg.nix
+++ b/modules/borg.nix
@@ -5,7 +5,7 @@
   ...
 }: {
   # BorgBackup (short: Borg) is a deduplicating backup program.
-  # https://nixos.wiki/wiki/Borg_backup
+  # https://wiki.nixos.org/wiki/Borg_backup
   # https://nixos.org/manual/nixos/stable/#module-borgbase
   # https://nixos.org/manual/nixos/stable/options#opt-services.borgbackup.jobs
   # https://borgbackup.readthedocs.io/en/stable/

--- a/modules/desktop/flatpak.nix
+++ b/modules/desktop/flatpak.nix
@@ -1,6 +1,6 @@
 {home-manager, ...}: {
   # https://flatpak.org/setup/NixOS
-  # https://nixos.wiki/wiki/Flatpak
+  # https://wiki.nixos.org/wiki/Flatpak
 
   services.flatpak.enable = true;
 

--- a/modules/desktop/gammastep.nix
+++ b/modules/desktop/gammastep.nix
@@ -2,7 +2,7 @@
   # Gammestep automatically adjusts the screen's colour temperature. It's
   # basically redshift for Wayland.
   # https://gitlab.com/chinstrap/gammastep
-  # https://nixos.wiki/wiki/Gammastep
+  # https://wiki.nixos.org/wiki/Gammastep
 
   home-manager.users.caspervk = {
     services.gammastep = {

--- a/modules/desktop/pipewire.nix
+++ b/modules/desktop/pipewire.nix
@@ -2,7 +2,7 @@
   # PipeWire is a new low-level multimedia framework. It aims to offer capture
   # and playback for both audio and video with minimal latency and support for
   # PulseAudio-, JACK-, ALSA- and GStreamer-based applications.
-  # https://nixos.wiki/wiki/PipeWire
+  # https://wiki.nixos.org/wiki/PipeWire
 
   services.pipewire = {
     enable = true;

--- a/modules/desktop/sway.nix
+++ b/modules/desktop/sway.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: {
-  # https://nixos.wiki/wiki/Sway
+  # https://wiki.nixos.org/wiki/Sway
 
   programs.sway = {
     enable = true;
@@ -295,7 +295,7 @@
     auth include login
   '';
 
-  # https://nixos.wiki/wiki/Fonts
+  # https://wiki.nixos.org/wiki/Fonts
   fonts = {
     enableDefaultPackages = true;
     packages = with pkgs; [

--- a/modules/desktop/virtd.nix
+++ b/modules/desktop/virtd.nix
@@ -1,5 +1,5 @@
 {home-manager, ...}: {
-  # https://nixos.wiki/wiki/Virt-manager
+  # https://wiki.nixos.org/wiki/Virt-manager
 
   virtualisation.libvirtd.enable = true;
   programs.virt-manager.enable = true;

--- a/modules/games.nix
+++ b/modules/games.nix
@@ -1,6 +1,6 @@
 {pkgs, ...}: {
-  # https://nixos.wiki/wiki/Lutris
-  # https://nixos.wiki/wiki/Steam
+  # https://wiki.nixos.org/wiki/Lutris
+  # https://wiki.nixos.org/wiki/Steam
   programs.steam.enable = true;
 
   environment.systemPackages = with pkgs; [

--- a/modules/server/acme.nix
+++ b/modules/server/acme.nix
@@ -10,7 +10,7 @@ lib.mkIf (config.security.acme.certs != {}) {
   # Instead of managing certificates in each individual service, NixOS supports
   # automatic certificate retrieval and renewal using
   # `security.acme.certs.<name>` through the ACME protocol.
-  # https://nixos.wiki/wiki/ACME
+  # https://wiki.nixos.org/wiki/ACME
   # https://nixos.org/manual/nixos/stable/index.html#module-security-acme
   security.acme = {
     acceptTerms = true;

--- a/modules/server/caddy.nix
+++ b/modules/server/caddy.nix
@@ -8,7 +8,7 @@
 lib.mkIf (config.services.caddy.virtualHosts != {}) {
   # Caddy is a powerful, enterprise-ready, open source web server with
   # automatic HTTPS written in Go.
-  # https://nixos.wiki/wiki/Caddy
+  # https://wiki.nixos.org/wiki/Caddy
   services.caddy = {
     enable = true;
   };


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️